### PR TITLE
Update main.asm

### DIFF
--- a/Digital_clock/main.asm
+++ b/Digital_clock/main.asm
@@ -719,7 +719,7 @@ RESET:
 			inc ss_time
 			jmp RETURN_RESET
 			CLEAR_UNI_SEG:
-				rcall FUNC_BUZZER 
+				; rcall FUNC_BUZZER 
 				andi ss_time, 0x0f ; Reset the last 4 bits of the register
 				jmp RETURN_RESET
 


### PR DESCRIPTION
This pull request includes several changes to the `Digital_clock/main.asm` file to improve the code's readability and functionality. The most important changes include rearranging variable definitions, correcting comments, and modifying register operations.

Improvements to variable definitions:

* Rearranged the definitions of `flag`, `byte_val`, `ascii_H`, `ascii_L`, `blink`, `crono`, and `delay` for better organization.

Corrections to comments:

* Corrected the comments for `BLINK_FOURTH_DISPLAY` and `BLINK_SECOND_DISPLAY` to specify "unit" instead of "uni".

Modifications to register operations:

* Changed the `DELAY` definition from `0.1` to `.1` for consistency.
* Modified the `CLEAR_UNI_MIN` section to correctly reset the lower part of the register using `andi mm_time, 0xf0`.
* Adjusted the `CLEAR_DEC_MIN` section to reset the last 4 bits of the register using `andi mm_time, 0x0f`.